### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,108 +1,64 @@
-# rtabmap_drone_example
-2D navigation example of a drone using [move_base](http://wiki.ros.org/move_base) with [mavros](http://wiki.ros.org/mavros)/[px4](https://github.com/PX4/PX4-Autopilot) and [rtabmap](wiki.ros.org/rtabmap_ros) visual SLAM. 
+# Navegación autónoma desdde ROS+PX4
 
-Overview video ([click](https://youtu.be/A487ybS7E4E) to watch on Youtube):
+Este framework fue desarrollado por los desarrolladores del código abierto de RTAB Map, el cual usa sensores de escaneo para hacer un análisis de imágenes de manera incremental, y con el algoritmo de cierre de bucle incremental actualiza su posición en tiempo real, dando por si solo una navegación muy eficiente en robótica, especialmente en las aplicaciones de drones debido a que da una localización precisa en las tres dimensiones de vuelo, algo que no ocurre con otros tipos de navegación.
+Ahora se explicará el proceso de instalación de este framework, primero se dan los requisitos de la máquina antes de la instalación del framework.
+•	Ubuntu 18.04 ó Ubuntu 20.04.
+•	ROS Noetic ó Melodic versión completa.
+•	Paquetes de ROS como octomap, mavros, rtabmap y vision_msgs.
+•	Framework de PX4-Autopilot.
+•	Gazebo.
+Una vez cumpliendo los requisitos mínimos, y se instalan los paquetes requeridos mostrados en los pasados informes, se procede a instalar las dependencias de ROS para nuestra máquina de ROS Noetic.
 
-[![Youtube](https://i.imgur.com/UKLtD7L.gif)](https://youtu.be/A487ybS7E4E)
+ ````
+sudo apt install ros-noetic-octomap* && sudo apt install ros-noetic-mavros* 
+sudo apt install ros-noetic-vision-msgs
+````
 
-## Install
+Se crea el workspace para el repositorio.
 
-### Docker (recommended)
-To make it simple, create the following docker image (nvidia GPU required):
-```bash
-git clone https://github.com/matlabbe/rtabmap_drone_example.git
-cd rtabmap_drone_example
-docker build -t rtabmap_drone_example -f docker/Dockerfile .
-```
+ ````
+mkdir ~/catkin_ws/src
+cd ~/catkin_ws/src
+git clone --recursive https://github.com/ProyectoDagger/Navegacion_autonoma_px4_ros.git
 
-### Host
-Follow instructions from [docker/Dockerfile](https://github.com/matlabbe/rtabmap_drone_example/blob/master/docker/Dockerfile) to install dependencies. 
+````
 
-## Usage
+Ahora se crea el espacio de trabajo con catkin.
+ ````
+cd catkin_ws
+catkin build
+````
+## Instalación PX4-Autopilot
 
-### Docker (recommended)
+Ahora se instala el código de PX4 Autopilot
+ ````
+cd ~
 
-Launch the simulator:
-```bash
-XAUTH=/tmp/.docker.xauth
-touch $XAUTH
-xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
+git clone https://github.com/PX4/PX4-Autopilot.git --recursive
+bash ./Tools/setup/ubuntu.sh
+````
+Junto a este, se instala Gazebo
+ ````
+cd ~
+curl -sSL http://get.gazebosim.org | sh
+````
+Finalmente, se pone en la carpeta raíz los siguientes parámetros
+ ````
+sudo nano ~./bashrc
 
-docker run -it --rm \
-  --privileged \
-  --network=host \
-  --env="DISPLAY=$DISPLAY" \
-  --env="QT_X11_NO_MITSHM=1" \
-  --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
-  --env="XAUTHORITY=$XAUTH" \
-  --volume="$XAUTH:$XAUTH" \
-  --runtime=nvidia \
-  rtabmap_drone_example \
-  roslaunch rtabmap_drone_example gazebo.launch
-```
-
-Launch VSLAM:
-```bash
-XAUTH=/tmp/.docker.xauth
-touch $XAUTH
-xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
-
-docker run -it --rm \
-  --privileged \
-  --network=host \
-  --env="DISPLAY=$DISPLAY" \
-  --env="QT_X11_NO_MITSHM=1" \
-  --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
-  --env="XAUTHORITY=$XAUTH" \
-  --volume="$XAUTH:$XAUTH" \
-  --runtime=nvidia \
-  rtabmap_drone_example \
-  roslaunch rtabmap_drone_example slam.launch
-```
-
-Launch rviz:
-```bash
-XAUTH=/tmp/.docker.xauth
-touch $XAUTH
-xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
-
-docker run -it --rm \
-  --privileged \
-  --network=host \
-  --env="DISPLAY=$DISPLAY" \
-  --env="QT_X11_NO_MITSHM=1" \
-  --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
-  --env="XAUTHORITY=$XAUTH" \
-  --volume="$XAUTH:$XAUTH" \
-  --runtime=nvidia \
-  rtabmap_drone_example \
-  roslaunch rtabmap_drone_example rviz.launch
-```
-
-Arm and take off:
-```bash
-docker run -it --rm \
-  --privileged \
-  --network=host \
-  rtabmap_drone_example \
-  rosrun rtabmap_drone_example offboard
-```
-
-### Host
-
-```bash
+sudo /opt/ros/noetic/setup.bash
+source PX4-Autopilot/Tools/setup_gazebo.bash $(pwd) $(pwd)/build/px4_sitl_default
+export ROS_PACKAGE_PATH=$ROS_PACKAGE_PATH:$(pwd)
+export ROS_PACKAGE_PATH=$ROS_PACKAGE_PATH:$(pwd)PX4-Autopilot/Tools/sitl_gazebo
+````
+Finalmente, se guarda el archivo con ctrl+X y se procede a iniciar la simulación.
+Para ejecutar la simulación, seguimos las siguientes líneas:
+ ````
+cd catkin_ws
+source devel/setup.bash
 roslaunch rtabmap_drone_example gazebo.launch
 roslaunch rtabmap_drone_example slam.launch
 roslaunch rtabmap_drone_example rviz.launch
-
-rosrun rtabmap_drone_example offboard
-```
-
-
-## Control
- * Autonomous control: use "2D Nav Goal" button in RVIZ to set a goal to reach
- * Manual control: If a joystick is plugged, you can send twists by holding L1 and moving the joysticks. Hold L1+L2 with left joystick down to land (be gentle to land smoothly), then hold left joystick in bottom-right position to disarm after the drone is on the ground.
- 
-
-![](https://raw.githubusercontent.com/matlabbe/rtabmap_drone_example/master/doc/example.jpg)
-
+rosrun rtabmap_drone_example offboard  
+````
+![image](https://github.com/ProyectoDAGGER/Navegacion_autonoma_px4_ros/assets/163484218/4636c046-a5da-485d-913e-5a92c3127b3a)


### PR DESCRIPTION
Para esta primera parte se recomienda probar en estudio Code

Requisitos previos de instalación

Antes de la implementación del framework, se deben cumplir los siguientes requisitos mínimos de sistema:

Sistema operativo Ubuntu 18.04 o Ubuntu 20.04.

Distribución completa de ROS Melodic o ROS Noetic.

Paquetes de ROS: octomap, mavros, rtabmap y vision_msgs.

Framework de vuelo PX4-Autopilot.

Simulador Gazebo para validación y pruebas en entorno virtual.

Instalación de dependencias ROS

Una vez verificados los requerimientos, se instalan los paquetes esenciales para ROS Noetic ejecutando los siguientes comandos:

sudo apt install ros-noetic-octomap*
sudo apt install ros-noetic-mavros*
sudo apt install ros-noetic-vision-msgs

Configuración del espacio de trabajo

Se procede a crear el espacio de trabajo para ROS y a clonar el repositorio correspondiente al módulo de navegación:

mkdir ~/catkin_ws/src
cd ~/catkin_ws/src
git clone --recursive https://github.com/ProyectoDagger/Navegacion_autonoma_px4_ros.git


Luego, se compila el entorno utilizando catkin:

cd ~/catkin_ws
catkin build

Instalación de PX4-Autopilot

El siguiente paso consiste en la instalación del sistema de control de vuelo PX4 Autopilot:

cd ~
git clone https://github.com/PX4/PX4-Autopilot.git --recursive
bash ./Tools/setup/ubuntu.sh

Instalación del simulador Gazebo

Para la simulación y validación de vuelo, se instala Gazebo mediante:

cd ~
curl -sSL http://get.gazebosim.org | sh

Configuración de entorno

Posteriormente, se deben agregar las rutas de entorno al archivo de configuración .bashrc:

sudo nano ~/.bashrc


Y se añaden las siguientes líneas:

source /opt/ros/noetic/setup.bash
source PX4-Autopilot/Tools/setup_gazebo.bash $(pwd) $(pwd)/build/px4_sitl_default
export ROS_PACKAGE_PATH=$ROS_PACKAGE_PATH:$(pwd)
export ROS_PACKAGE_PATH=$ROS_PACKAGE_PATH:$(pwd)/PX4-Autopilot/Tools/sitl_gazebo


Una vez guardados los cambios (Ctrl + X, luego Y y Enter), el entorno queda configurado para la simulación.

Ejecución de la simulación

Con todos los componentes instalados, se puede iniciar la simulación mediante los siguientes comandos:

cd ~/catkin_ws
source devel/setup.bash
roslaunch rtabmap_drone_example gazebo.launch
roslaunch rtabmap_drone_example slam.launch
roslaunch rtabmap_drone_example rviz.launch
rosrun rtabmap_drone_example offboard